### PR TITLE
✨ feat: start chess piece domain model

### DIFF
--- a/packages/chess-engine/src/pieces/Pawn.ts
+++ b/packages/chess-engine/src/pieces/Pawn.ts
@@ -1,0 +1,11 @@
+// Pawn.ts
+
+import type { Position } from "../types/position.js";
+import { Piece } from "./Piece.js";
+
+export class Pawn extends Piece {
+  // pawn-specific movement
+  getMoves(): Position[] {
+    return [];
+  }
+}

--- a/packages/chess-engine/src/pieces/Piece.ts
+++ b/packages/chess-engine/src/pieces/Piece.ts
@@ -1,0 +1,14 @@
+// Piece.ts
+
+import type { Position } from "../types/position.ts";
+
+export type Color = "white" | "black";
+
+export abstract class Piece {
+  constructor(
+    public readonly color: Color,
+    public position: Position,
+  ) {}
+
+  abstract getMoves(): Position[];
+}

--- a/packages/chess-engine/src/types/position.ts
+++ b/packages/chess-engine/src/types/position.ts
@@ -1,0 +1,6 @@
+// Position.ts
+
+export type Position = {
+  file: number;
+  rank: number;
+};


### PR DESCRIPTION
# Start chess engine piece implementation
Begin implementation of the chess engine's piece domain model.

## Changes
- Added the base Piece abstraction
- Added the initial Pawn implementation
- Added the Color type
- Added the Position type
- Established piece identity through classes
- Added the getMoves() contract for chess pieces
- Started migrating the prototype piece structure toward the TypeScript engine architecture